### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,16 +17,16 @@ limitations under the License.
 <html>
 <head>
   <meta charset=utf-8 />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Firebase Cloud Messaging Example</title>
 
   <!-- Material Design Theming -->
-  <link rel="stylesheet" href="https://code.getmdl.io/1.1.3/material.orange-indigo.min.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://code.getmdl.io/1.1.3/material.orange-indigo.min.css"/>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>
   <script defer src="https://code.getmdl.io/1.1.3/material.min.js"></script>
   <script src="vanilla.js"></script>
 
-  <link rel="manifest" href="manifest.json">
+  <link rel="manifest" href="manifest.json"/>
 </head>
 <body>
 


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tags anyhow - that is not an excuse for not writing specification valid code. And given the spirit of open-source community, I will be more than happy to push these improvements to you. The changes in this Pull-Request will not break your HTML code, and they have also been manually inspected, to ensure the only change is closing of void elements.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
